### PR TITLE
HIP support + Used platform info logged in file + Multiple GPU support

### DIFF
--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -163,6 +163,8 @@ class MiChroM:
         elif platform.lower() == "cpu":
             platformObject = self.mm.Platform.getPlatformByName('CPU')
 
+        elif platform.lower() == "hip":
+            platformObject = self.mm.Platform.getPlatformByName('HIP')
 
         else:
             self.exit("\n!!!! Unknown platform !!!!\n")
@@ -889,7 +891,13 @@ class MiChroM:
         self.initPositions()
         self.initVelocities()
         self.forcesApplied = True
-      
+     
+        with open(self.folder+'/platform_info.dat', 'w') as f:
+                print('Name: ', self.platform.getName(), file=f)
+                print('Speed: ',self.platform.getSpeed(), file=f)
+                print('Property names: ',self.platform.getPropertyNames(), file=f)
+                for name in self.platform.getPropertyNames():
+                     print(name,' value: ',self.platform.getPropertyValue(self.context, name), file=f) 
 
     def createRandomWalk(self, step_size=1.0, Nbeads=1000, segment_length=1):    
         R"""

--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -82,14 +82,14 @@ class MiChroM:
             
 
     def setup(self, platform="CUDA", PBC=False, PBCbox=None, GPU="default",
-              integrator="langevin", errorTol=None, precision="mixed"):
+              integrator="langevin", errorTol=None, precision="mixed",deviceIndex="0"):
         
         R"""Sets up the parameters of the simulation OpenMM platform.
 
         Args:
 
             platform (str, optional):
-                Platform to use in the simulations. Opitions are *CUDA*, *OpenCL*, *CPU*, *Reference*. (Default value: *CUDA*). 
+                Platform to use in the simulations. Opitions are *CUDA*, *OpenCL*, *HIP*, *CPU*, *Reference*. (Default value: *CUDA*). 
 
             PBC (bool, optional)
                 Whether to use periodic boundary conditions. (Default value: :code:`False`). 
@@ -104,6 +104,8 @@ class MiChroM:
                 Integrator to use in the simulations. Options are *langevin*,  *variableLangevin*, *verlet*, *variableVerlet* and, *brownian*. (Default value: *langevin*).
             verbose (bool, optional):
                 Whether to output the information in the screen during the simulation. (Default value: :code:`False`).
+            deviceIndex (str, optional):
+                Set of Platform device index IDs. Ex: 0,1,2 for the system to use the devices 0, 1 and 2. (Use only when GPU != default)
 
             errorTol (float, required if **integrator** = *variableLangevin*):
                 Error tolerance parameter for *variableLangevin* integrator.
@@ -147,7 +149,7 @@ class MiChroM:
         self.GPU = str(GPU)
         properties = {}
         if self.GPU.lower() != "default":
-            properties["DeviceIndex"] = str(GPU)
+            properties["DeviceIndex"] = deviceIndex
             properties["Precision"] = precision
         self.properties = properties
 


### PR DESCRIPTION
Added HIP platform option and information of the platform used is saved in a file inside the output folder. 
Inside the output folder, a file called 'platform_info.dat' is created describing where the code is running and the platform variable details. 
Example #1  - HIP support:
`
Name:  HIP
Speed:  100.0
Property names:  ('DeviceIndex', 'DeviceName', 'UseBlockingSync', 'Precision', 'UseCpuPme', 'HipCompiler', 'TempDirectory', 'HipHostCompiler', 'DisablePmeStream', 'DeterministicForces')
DeviceIndex  value:  0
DeviceName  value:  Device 66a1
UseBlockingSync  value:  true
Precision  value:  double
UseCpuPme  value:  false
HipCompiler  value:  /opt/rocm/bin/hipcc
TempDirectory  value:  /tmp
HipHostCompiler  value:
DisablePmeStream  value:  false
DeterministicForces  value:  false
`

Example #2 - Multiple GPU support:
 `
Name:  HIP
Speed:  100.0
Property names:  ('DeviceIndex', 'DeviceName', 'UseBlockingSync', 'Precision', 'UseCpuPme', 'HipCompiler', 'TempDirectory', 'HipHostCompiler', 'DisablePmeStream', 'DeterministicForces')
DeviceIndex  value:  0,1,2,3,4,5,6,7
DeviceName  value:  Device 66a1,Device 66a1,Device 66a1,Device 66a1,Device 66a1,Device 66a1,Device 66a1,Device 66a1
UseBlockingSync  value:  true
Precision  value:  double
UseCpuPme  value:  false
HipCompiler  value:  /opt/rocm/bin/hipcc
TempDirectory  value:  /tmp
HipHostCompiler  value:
DisablePmeStream  value:  false
DeterministicForces  value:  false
`

Example #3 - OpenCL platform info:
`
Name:  OpenCL
Speed:  50.0
Property names:  ('DeviceIndex', 'DeviceName', 'OpenCLPlatformIndex', 'OpenCLPlatformName', 'Precision', 'UseCpuPme', 'DisablePmeStream')
DeviceIndex  value:  0
DeviceName  value:  gfx906:sramecc+:xnack-
OpenCLPlatformIndex  value:  0
OpenCLPlatformName  value:  AMD Accelerated Parallel Processing
Precision  value:  double
UseCpuPme  value:  false
DisablePmeStream  value:  false
`