### PR TITLE
updated documentation for addLoops and changes in addAdditionalForce to accept user defined forces

### DIFF
--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -1089,20 +1089,26 @@ class MiChroM:
                 Arguments of the function to add the force. Consult respective documentation.
         """
         
-        assert isinstance(forceFunction, types.MethodType), f"No function with name {forceFunction}! \
-                                                You can only add functions that are defined as a method of the simulation object"
+        # warning for user defined force function
+        if not isinstance(forceFunction, types.MethodType):
+            print("WARNING! Using user defined force function. Make sure to include the new force object in the MiChroM.forceDict dictionary.")
+
         #store old forcedict keys
-        oldForceDictKeys = list(self.forceDict.keys())
+        oldForceDictKeys = self.forceDict.keys()
         
         # call the function --  
         # the force name is added to the forceDict but not yet added to the system
         forceFunction(**args)
 
         # find the new forceDict name
-        newForceDictKey_list = list(set(oldForceDictKeys)^set(self.forceDict.keys()))
-        assert len(newForceDictKey_list)==1, "The force you are adding is already present! Try removing it first and then add"
-        newForceDictKey = newForceDictKey_list[0]
-        force = self.forceDict[newForceDictKey]
+        newForceDictKey = [x for x in self.forceDict.keys() if x not in oldForceDictKeys]
+
+        if len(newForceDictKey) == 0:
+            raise Exception("No new force in MiChroM.forceDict! The new force is either already present or was not added properly to the force dictionary.")
+        elif len(newForceDictKey) > 1:
+            raise Exception("Force function added multiple new forces in MiChroM! Please break down the function so each force is added separately.")
+        
+        force = self.forceDict[newForceDictKey[0]]
         
         # exclusion list
         exc = self.bondsForException

--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -23,6 +23,7 @@ except:
 
 
 from sys import stdout
+import warnings
 import numpy as np
 from six import string_types
 import os
@@ -1091,7 +1092,7 @@ class MiChroM:
         
         # warning for user defined force function
         if not isinstance(forceFunction, types.MethodType):
-            print("WARNING! Using user defined force function. Make sure to include the new force object in the MiChroM.forceDict dictionary.")
+            warnings.warn("Using user defined force function. Make sure to include the new force object in the MiChroM.forceDict dictionary.")
 
         #store old forcedict keys
         oldForceDictKeys = list(self.forceDict.keys())

--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -1077,7 +1077,7 @@ class MiChroM:
         self.removeForce(forceName)
 
 
-    def addAdditionalForce(self, forceFunction, **args):
+    def addAdditionalForce(self, forceFunction, *args, **kwargs):
         R"""
         Add an additional force after the system has already been initialized.
 
@@ -1094,21 +1094,26 @@ class MiChroM:
             print("WARNING! Using user defined force function. Make sure to include the new force object in the MiChroM.forceDict dictionary.")
 
         #store old forcedict keys
-        oldForceDictKeys = self.forceDict.keys()
+        oldForceDictKeys = list(self.forceDict.keys())
         
         # call the function --  
         # the force name is added to the forceDict but not yet added to the system
-        forceFunction(**args)
+        forceFunction(*args, **kwargs)
 
         # find the new forceDict name
-        newForceDictKey = [x for x in self.forceDict.keys() if x not in oldForceDictKeys]
-
-        if len(newForceDictKey) == 0:
-            raise Exception("No new force in MiChroM.forceDict! The new force is either already present or was not added properly to the force dictionary.")
-        elif len(newForceDictKey) > 1:
-            raise Exception("Force function added multiple new forces in MiChroM! Please break down the function so each force is added separately.")
+        newKeys = list(set(oldForceDictKeys)^set(self.forceDict.keys()))
         
-        force = self.forceDict[newForceDictKey[0]]
+        try:
+            newForceDictKey = newKeys.pop()
+        except:
+            newForceDictKey = None
+        finally:
+            if newForceDictKey is None:
+                raise ValueError("No new force in MiChroM.forceDict! The new force is either already present or was not added properly to the force dictionary.")
+            if newKeys:
+                raise ValueError("Force function added multiple new forces in MiChroM! Please break down the function so each force is added separately.")
+        
+        force = self.forceDict[newForceDictKey]
         
         # exclusion list
         exc = self.bondsForException

--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -334,6 +334,7 @@ class MiChroM:
         data = data + np.random.randn(*data.shape) * 0.0001
         self.setPositions(data)
         
+
     def getLoops(self, looplists):
         R"""
         Get the loop position (CTFC anchor points) for each chromosome.
@@ -342,8 +343,8 @@ class MiChroM:
 
         Args:
 
-            looplists (text file): 
-                A two-column text file containing the index *i* and *j* of a loci pair that form loop interactions.
+            looplists (list[str]): 
+                List with the names of the files containing loop information. Each file should be a two-column text file containing the index *i* and *j* of the loci pairs that forms the loop anchors.
         """
         self.loopPosition = []
         for file, chain in zip(looplists,self.chains):
@@ -685,10 +686,13 @@ class MiChroM:
                 Parameter in the probability of crosslink function, :math:`f(rc) = 0.5`. (Default value = 1.78).
             X (float, required):
                 Loop interaction parameter. (Default value = -1.612990).
-            looplists (file, optional):
-                A two-column text file containing the index *i* and *j* of a loci pair that form loop interactions. (Default value: :code:`None`).
+            looplists (list[str], required): 
+                List with the names of the files containing loop information. Each file should be a two-column text file containing the index *i* and *j* of the loci pairs that forms the loop anchors. (Default value: :code:`None`).
         """
-            
+        
+        if isinstance(looplists, str):
+            looplists = [looplists]
+
         ELoop = "qsi*0.5*(1. + tanh(mu*(rc - r)))"
                 
         Loop = self.mm.CustomBondForce(ELoop)


### PR DESCRIPTION
- Updated the documentation of `addLoops` and `getLoops` to specify that the variable `looplists` receives a `list[str]` with the name of the files with the loop lists
- Added a error checking to accept when user pass a `str` in the single chromosome case when using `addLoops`
- `addAdditionalForce` now allows user defined force functions
- changed error checking in `addAdditionalForce` to make clearer that the `forceFunction` can only add one new force into the `forceDict`
- updated the `*args` in `addAdditionalForce` to fix a bug when using positional arguments instead of keyword argument