### PR TITLE
Correct behavior of `saveStructure` and minor enhancements

### DIFF
--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -113,7 +113,7 @@ class MiChroM:
         self.gpu = str(gpu)
 
         # Define the platform priority order
-        default_platforms = {'cuda': 'CUDA', 'hip': 'HIP', 'opencl': 'OpenCL', 'cpu': ' CPU'}
+        default_platforms = {'cuda': 'CUDA', 'hip': 'HIP', 'opencl': 'OpenCL', 'cpu': 'CPU'}
 
         # Rearrange the platform priority so that the specified platform is first
         preferred_platform = default_platforms[platform.lower()]

--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -2025,9 +2025,20 @@ class MiChroM:
         if not hasattr(self, "type_list_letter"):
             raise ValueError("Chromatin sequence not defined!")
         
+        if filename is None:
+            if len(self.chains) > 1:
+                filename_format = "{name}_{chain}_step{step}.{mode}"
+            else:
+                filename_format = "{name}_step{step}.{mode}"
+        else:
+            if len(self.chains) > 1:
+                filename_format = os.path.splitext(filename)[0] + "_{chain}.{mode}"
+            else:
+                filename = os.path.splitext(filename)[0] + ".{mode}"
+        
         if mode == "xyz":
-            if filename is None:
-                filename = self.name +"_step%d." % self.simulation.currentStep + mode
+
+            filename = filename_format.format(name=self.name, chain=0, step=self.simulation.currentStep, mode=mode)
             filename = os.path.join(self.folder, filename)
             
             lines = []
@@ -2055,8 +2066,7 @@ class MiChroM:
             for chainNum, chain in zip(range(len(self.chains)),self.chains):
                 pdb_string = []
 
-                if filename is None:
-                    filename = self.name +"_" + str(chainNum) + "_step%d." % self.simulation.currentStep + mode
+                filename = filename_format.format(name=self.name, chain=chainNum, step=self.simulation.currentStep, mode=mode)
                 filename = os.path.join(self.folder, filename)
 
                 data_chain = data[chain[0]:chain[1]+1]
@@ -2090,8 +2100,7 @@ class MiChroM:
                 
                 gro_string = []
 
-                if filename is None:
-                    filename = self.name +"_" + str(chainNum) + "_step%d." % self.simulation.currentStep + mode
+                filename = filename_format.format(name=self.name, chain=chainNum, step=self.simulation.currentStep, mode=mode)
                 filename = os.path.join(self.folder, filename)
                 
                 data_chain = data[chain[0]:chain[1]+1] 
@@ -2132,8 +2141,7 @@ class MiChroM:
                 return ([l[i:i+n] for i in range(0, len(l), n)])
             
             for chainNum, chain in zip(range(len(self.chains)),self.chains):
-                if filename is None:
-                    filename = self.name +"_" + str(chainNum) + "_step%d." % self.simulation.currentStep + mode
+                filename = filename_format.format(name=self.name, chain=chainNum, step=self.simulation.currentStep, mode=mode)
                 filename = os.path.join(self.folder, filename)
                 
                 ndbf = []

--- a/OpenMiChroM/ChromDynamics.py
+++ b/OpenMiChroM/ChromDynamics.py
@@ -1357,7 +1357,7 @@ class MiChroM:
                 self.simulation.reporters.append(simulation_reporter)
 
 
-    def run(self, nsteps, report=True, interval=10**4):
+    def run(self, nsteps, report=True, interval=10**4, totalSteps=None):
         R"""
         Executes the simulation for a specified number of steps, with optional progress reporting.
 
@@ -1367,7 +1367,7 @@ class MiChroM:
 
         Args:
             nsteps (int):
-                The total number of steps to execute in the simulation. Must be a positive integer.
+                The number of steps to execute in the simulation. Must be a positive integer.
             
             report (bool, optional):
                 Determines whether to enable progress reporting during the simulation run.
@@ -1380,15 +1380,25 @@ class MiChroM:
                 Must be a positive integer.
                 Default is `10**4` (10,000 steps).
 
+            totalSteps (int):
+                The total number of steps planned for the simulation. Must be a positive integer.
+                This defines how many steps will indicate 100% completion. If the simulation pipeline
+                includes multiple `run` calls, this number should be the sum of `nsteps` in all of them.
+                If `None`, `totalSteps = nsteps`.
+                Default is `None`.
+
         Example:
             ```python
             # Run the simulation for 500,000 steps with progress reporting every 5,000 steps
             simulation.run(nsteps=500000, report=True, interval=5000)
             ```
         """
+        if totalSteps is None:
+            totalSteps = nsteps
+            
         if report:
             self.simulation.reporters.append(StateDataReporter(stdout, interval, step=True, remainingTime=True,
-                                                  progress=True, speed=True, totalSteps=nsteps, separator="\t"))
+                                                  progress=True, speed=True, totalSteps=totalSteps, separator="\t"))
         
         self.simulation.step(nsteps)
 

--- a/OpenMiChroM/CndbTools.py
+++ b/OpenMiChroM/CndbTools.py
@@ -127,17 +127,17 @@ class cndbTools:
         cndbf.close()
         return(name)
     
-    def xyz(self, frames=[1,None,1], beadSelection=None, XYZ=[0,1,2]):
+    def xyz(self, frames=None, beadSelection=None, XYZ=[0,1,2]):
         R"""
         Get the selected beads' 3D position from a **cndb** or **ndb** for multiple frames.
         
         Args:
             frames (list, required):
-                Define the range of frames that the position of the bead will get extracted. The range list is defined by :code:`frames=[initial, final, step]`. (Default value: :code: `[1,None,1]`, all frames)
+                Define which frames to extract the position of the selected beads. The list should include all frames to iterate over, or a iterator that goes over the desired frames. (Default value: `None`, all frames)
             beadSelection (list of ints, required):
-                List of beads to extract the 3D position for each frame. The list is defined by :code: `beadSelection=[0,1,2,...,N-1]`. (Default value: :code: `None`, all beads) 
+                List of beads to extract the 3D position for each frame. The list is defined by `beadSelection=[0,1,2,...,N-1]`. (Default value: `None`, all beads) 
             XYZ (list, required):
-                List of the axis in the Cartesian coordinate system that the position of the bead will get extracted for each frame. The list is defined by :code: `XYZ=[0,1,2]`. where 0, 1 and 2 are the axis X, Y and Z, respectively. (Default value: :code: `XYZ=[0,1,2]`) 
+                List of the axis in the Cartesian coordinate system that the position of the bead will get extracted for each frame. The list is defined by `XYZ=[0,1,2]`. where 0, 1 and 2 are the axis X, Y and Z, respectively. (Default value: `XYZ=[0,1,2]`) 
     
         Returns:
             (:math:`N_{frames}`, :math:`N_{beads}`, 3) :class:`numpy.ndarray`: Returns an array of the 3D position of the selected beads for different frames.
@@ -149,10 +149,10 @@ class cndbTools:
         else:
             selection = np.array(beadSelection)
             
-        if frames[1] == None:
-            frames[1] = self.Nframes
+        if frames == None:
+            frames = range(1,self.Nframes+1,1)
         
-        for i in range(frames[0],frames[1],frames[2]):
+        for i in frames:
             frame_list.append(np.take(np.take(np.array(self.cndb[str(i)]), selection, axis=0), XYZ, axis=1))
         return(np.array(frame_list))
     
@@ -170,7 +170,7 @@ class cndbTools:
         
         Args:
             xyz (:math:`(frames, beadSelection, XYZ)` :class:`numpy.ndarray`, required):
-                Array of the 3D position of the selected beads for different frames extracted by using the :code: `xyz()` function.
+                Array of the 3D position of the selected beads for different frames extracted by using the `xyz()` function.
             chrom_start (int, required):
                 First bead to consider in the calculations (Default value = 0).
             chrom_end (int, required):
@@ -217,7 +217,7 @@ class cndbTools:
         
         Args:
             xyz (:math:`(frames, beadSelection, XYZ)` :class:`numpy.ndarray`, required):
-                Array of the 3D position of the selected beads for different frames extracted by using the :code: `xyz()` function.
+                Array of the 3D position of the selected beads for different frames extracted by using the `xyz()` function.
             lowcut (int, required):
                 Filter to cut low frequencies (Default value = 1).
             highcut (int, required):
@@ -263,7 +263,7 @@ class cndbTools:
         
         Args:
             xyz (:math:`(frames, beadSelection, XYZ)` :class:`numpy.ndarray`, required):
-                Array of the 3D position of the selected beads for different frames extracted by using the :code: `xyz()` function.
+                Array of the 3D position of the selected beads for different frames extracted by using the `xyz()` function.
             neig_beads (int, required):
                 Number of neighbor beads to consider in the calculation (Default value = 4).  
                        
@@ -296,7 +296,7 @@ class cndbTools:
         
         Args:
             xyz (:math:`(frames, beadSelection, XYZ)` :class:`numpy.ndarray` (dim: TxNx3), required):
-                Array of the 3D position of the selected beads for different frames extracted by using the :code: `xyz()` function.  
+                Array of the 3D position of the selected beads for different frames extracted by using the `xyz()` function.  
                        
         Returns:
             :class:`numpy.ndarray` (dim: Tx1):
@@ -320,7 +320,7 @@ class cndbTools:
 
         Args:
             xyz (:math:`(frames, beadSelection, XYZ)` :class:`numpy.ndarray` (dim: TxNx3), required):
-                Array of the 3D position of the selected beads for different frames extracted by using the :code: `xyz()` function.  
+                Array of the 3D position of the selected beads for different frames extracted by using the `xyz()` function.  
                        
         Returns:
             :class:`numpy.ndarray` (dim: Tx3):
@@ -343,7 +343,7 @@ class cndbTools:
         
         Args:
             xyz (:math:`(frames, beadSelection, XYZ)` :class:`numpy.ndarray` (dim: TxNx3), required):
-                Array of the 3D position of the selected beads for different frames extracted by using the :code: `xyz()` function.  
+                Array of the 3D position of the selected beads for different frames extracted by using the `xyz()` function.  
                        
         Returns:
             :class:`numpy.ndarray` (dim: NxT):
@@ -389,7 +389,7 @@ class cndbTools:
         
         Args:
             xyz (:math:`(frames, beadSelection, XYZ)` :class:`numpy.ndarray` (dim: TxNx3), required):
-                Array of the 3D position of the selected beads for different frames extracted by using the :code: `xyz()` function.  
+                Array of the 3D position of the selected beads for different frames extracted by using the `xyz()` function.  
 
             dr (float, required):
                 mesh size of radius for calculating the radial distribution. 
@@ -460,9 +460,9 @@ class cndbTools:
         
         Args:
             xyz (:math:`(frames, XYZ)` :class:`numpy.ndarray`, required):
-                Array of the 3D position of the frames extracted by using the :code: `xyz()` function. 
+                Array of the 3D position of the frames extracted by using the `xyz()` function. 
             beadSelection (:math:`(beadSelection)` :class:`numpy.ndarray`):
-                The index of the beads to be sliced from `xyz` that you want to compute RDP. Usualy, you can use the internal selection using the :code: `dictChromSeq['types']` with 'types' been the selection that you want. 
+                The index of the beads to be sliced from `xyz` that you want to compute RDP. Usualy, you can use the internal selection using the `dictChromSeq['types']` with 'types' been the selection that you want. 
             radius (float, required):
                 Radius of the sphere in units of :math:`\sigma` to be considered in the calculations. The radius value should be modified depending on your simulated chromosome length. (Default value = 20.0).
             bins (int, required):

--- a/OpenMiChroM/CndbTools.py
+++ b/OpenMiChroM/CndbTools.py
@@ -209,7 +209,7 @@ class cndbTools:
         return np.asarray(Oijx),np.asarray(Oijy)
 
 
-    def compute_FFT_from_Oij(Oijy,lowcut=1, highcut=500, order=5):
+    def compute_FFT_from_Oij(self, Oijy, lowcut=1, highcut=500, order=5):
         from scipy.signal import butter, lfilter
         from scipy.fftpack import fft
         R"""
@@ -232,30 +232,31 @@ class cndbTools:
             yf:class:`numpy.ndarray`:
                 Returns the Fourier transform of the Orientation Order Parameter OP in space of 1/Chrom_Length.
         """
+
+        def _butter_bandpass(lowcut, highcut, fs, order=5):
+            R"""
+            Internal function for selecting frequencies.
+            """
+            nyq = fs//2
+            low = lowcut / nyq
+            high = highcut / nyq
+            b, a = butter(order, [low, high], btype='band')
+            return b, a
+        
+        def _butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
+            R"""
+            Internal function for filtering bands.
+            """
+            b, a = _butter_bandpass(lowcut, highcut, fs, order=order)
+            y = lfilter(b, a, data)
+            return y
+        
         N=np.shape(Oijy)[0]
-        y = _butter_bandpass_filter(Oijy, lowcut, highcut, N, order=5)
+        y = _butter_bandpass_filter(Oijy, lowcut, highcut, N, order=order)
         xf = np.linspace(1, N//2 , N//2)
         yf=fft(y)/len(y)
         return (xf[0:N//2]-1)/N,np.abs(yf[0:N//2])
-
-    def _butter_bandpass(lowcut, highcut, fs, order=5):
-        R"""
-        Internal function for selecting frequencies.
-        """
-        nyq = fs//2
-        low = lowcut / nyq
-        high = highcut / nyq
-        b, a = butter(order, [low, high], btype='band')
-        return b, a
-
-
-    def _butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
-        R"""
-        Internal function for filtering bands.
-        """
-        b, a = _butter_bandpass(lowcut, highcut, fs, order=order)
-        y = lfilter(b, a, data)
-        return y
+    
 
     def compute_Chirality(self,xyz,neig_beads=4):
         R"""

--- a/OpenMiChroM/CustomReporter.py
+++ b/OpenMiChroM/CustomReporter.py
@@ -25,7 +25,7 @@ class SaveStructure(StateDataReporter):
     def __init__(self, filePrefix, reportInterval, mode='cndb', folder='.',
                  chains=None, typeListLetter=None, diffTypes=None):
         #super().__init__(reportInterval)
-        super(SaveStructure, self).__init__(filePrefix, reportInterval)
+        # super(SaveStructure, self).__init__(filePrefix, reportInterval)
         self.filePrefix = filePrefix
         self.reportInterval = reportInterval
         self.mode = mode.lower()


### PR DESCRIPTION
- Fixed behavior of `saveStructure` to be consistent with current versions of the code. 
- Included `totalSteps` argument in `MiChroM.run()` to allow for proper outputting when calling the function more than once.
- Changed `frames` notation in `xyz` inside `CndbTools`, to allow for more flexible frame selection.