### PR TITLE
Fix compute_Chirality loop bound

### DIFF
--- a/OpenMiChroM/CndbTools.py
+++ b/OpenMiChroM/CndbTools.py
@@ -276,7 +276,7 @@ class cndbTools:
         for frame in range(len(xyz)):
             XYZ = xyz[frame]
             Psi_per_bead=[]
-            for i in range(0,np.shape(xyz)[0] - np.ceil(1.25*neig_beads).astype('int')):
+            for i in range(0,np.shape(XYZ)[0] - np.ceil(1.25*neig_beads).astype('int')):
                 a=i
                 b=int(np.round(i+0.5*neig_beads))
                 c=int(np.round(i+0.75*neig_beads))


### PR DESCRIPTION
The inner loop in `cndbTools.compute_Chirality` iterates over bead indices but uses `np.shape(xyz)[0]` (number of frames) as the upper limit, when it should be `np.shape(XYZ)[0]` (number of beads, i.e. the per-frame array).

Effect:
- `n_frames > n_beads` → `IndexError` on `XYZ[d]`
- `n_frames < n_beads` → silently truncates output to the first few beads
- `n_frames == n_beads` → works by coincidence

The fix is a single-character change.